### PR TITLE
fix: render the editor image node inline

### DIFF
--- a/resources/js/components/Form/Editor.vue
+++ b/resources/js/components/Form/Editor.vue
@@ -99,7 +99,9 @@
                     Highlight,
                     History,
                     HorizontalRule,
-                    Image,
+                    Image.configure({
+                        inline: true,
+                    }),
                     Italic,
                     Link.configure({ openOnClick: false }),
                     ListItem,


### PR DESCRIPTION
This allows images to be linked to urls.